### PR TITLE
Fix error dealing with empty data + add table of content README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ Test GCP Cloud Functions locally
 
 <br>
 
-## Basic Description
+## Table of Contents
+
+* [Basic Description](#basic-description)
+* [Installation](#installation)
+* [Using cloud-function-test](#using-cloud-function-test)
+    * [General Functioning](#general-functioning)
+    * [Http-triggered Functions](#http-triggered-functions)
+    * [Wildcards for Expected Content](#wildcards-for-expected-content)
+    * [Event-triggered Functions](#event-triggered-functions)
+    * [Settings](#settings)
+* [Contributing](#contributing)
+* [Contact](#contact)
+
+<br>
+
+## Basic Description <a name="basic-description"></a>
 
 The objective of this package is to allow you to easily test your GCP Cloud Functions locally before deploying them. The package relies on Google's functions-framework to launch a local server that receives requests triggering your Cloud Function. Even though the functions are triggered through a request in the package's testing mechanism, event-triggered Cloud Functions are also supported.
 The package's interface is intended to look similar to that of popular python unit-testing libraries. You can define different tests as classes in a python file, specifying the input and the expected output. You can then launch the tests from the cli and the results are printed unto your terminal.
@@ -61,10 +76,19 @@ Unexpected output
 
 <br>
 
-## Detailed description
+## Installation <a name="installation"></a>
 
+To install the latest version of the package:
 
-### General Functioning
+```bash
+pip install cloud-function-test
+```
+
+<br>
+
+## Using cloud-function-test <a name="using-cloud-function-test"></a>
+
+### General Functioning <a name="general-functioning"></a>
 
 In your test module, `cf_tests.py` by default, you need to create a basic class for each of your test.
 
@@ -73,22 +97,22 @@ Each class can have a set of attributes that work as parameters for the test. Al
 If you do specifiy some of those attributes, you need to make sure their value is of a supported type.
 
 There are 2 possible attributes that are common to both http-triggered and event-triggerd functions:
-* error (bool): indicates whether the test is expected to raise an Exception. The test will succeed if the function crashes while it will fail if it runs without error
-* display_logs (bool): indicates whether the logs and the return value should be displayed even in case of success (they are always displayed in case of failure of the test)
+* `error` (bool): indicates whether the test is expected to raise an Exception. The test will succeed if the function crashes while it will fail if it runs without error
+* `display_logs` (bool): indicates whether the logs and the return value should be displayed even in case of success (they are always displayed in case of failure of the test)
 
 
-### Http-triggered Functions
+### Http-triggered Functions <a name="http-triggered-functions"></a>
 
 This package has primarily been made for http-triggered Cloud Function so your test classes will be considered to be for this kind of function by default.
 
 You can specify 4 additional attributes for those:
-* data (dict, list): the payload that will be included in the request triggering your function
-* headers (dict): the headers that will be included in the request triggering your function
-* status_code (dict, list): the status code your function is expected to return giving the parameters provided
-* output (dict, list): the output your function is expected to return giving the parameters provided. Details on the specific structure the value of this attribute can take are specified below
+* `data` (dict, list): the payload that will be included in the request triggering your function
+* `headers` (dict): the headers that will be included in the request triggering your function
+* `status_code` (dict, list): the status code your function is expected to return giving the parameters provided
+* `output` (dict, list): the output your function is expected to return giving the parameters provided. Details on the specific structure the value of this attribute can take are specified below
 
 
-### Wildcards for Expected Content
+### Wildcards for Expected Content <a name="wildcards-for-expected-content"></a>
 
 It's quite common to want to check the validity of the output of an http-triggered Cloud Function without knowing the exact value of the expected output. This happens for instance if you Cloud Function is calling an external service or if your output includes an "updated_at" timestamp. In that case, you may want to test that the structure of the output is correct rather than the exact content.
 
@@ -124,16 +148,16 @@ There are 2 types of wildcards your can use for that purpose:
     
     We cannot ensure you that the most complex cases are covered unfortunately
 
-### Event-triggered Functions
+### Event-triggered Functions <a name="event-triggered-functions"></a>
 
 Testing event-triggered functions is not as straightforward as for http-triggered ones. Since we cannot fully simulate the underlying event for which GCP would trigger the function, we make a request to it as a workaround. In the definition of your test class, you can specify the event and the context you want your function to receive as dictionaries. The package will then pass them on your function.
 
 You can specify 2 additional attributes for those:
-* event (dict): the event that your function will receive
-* context (dict): the context that you function will receive
+* `event` (dict): the event that your function will receive
+* `context` (dict): the context that you function will receive
 
 
-### Settings
+### Settings <a name="settings"></a>
 
 There are 5 options you can modify for running your tests. Those can typically be modified either in your test module or in the cli
 
@@ -193,3 +217,20 @@ There are 5 options you can modify for running your tests. Those can typically b
    ```
    import cloud_function_framework
    cloud_function_framework.port = <port>
+
+<br>
+
+## Contributing <a name="contributing"></a>
+
+Your contribution is very much welcome, both through the creation of issues and through the opening of pull requests. To open a pull request:
+1. Fork the repo
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -m 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request
+
+<br>
+
+## Contact <a name="contacts"></a>
+
+You can reach out to me at: robin.picard@sciencespo.fr

--- a/cloud_function_test/test_classes/event_test.py
+++ b/cloud_function_test/test_classes/event_test.py
@@ -36,9 +36,9 @@ class EventFunctionTest(BaseFunctionTest):
         """
         params = {'url': url, 'headers': {'Content-Type': 'application/json'}}
         data = {}
-        if self.event:
+        if self.event is not None:
             data['event'] = self.event
-        if self.context:
+        if self.context is not None:
             data['context'] = self.context
         if data:
             params['json'] = data

--- a/cloud_function_test/test_classes/http_test.py
+++ b/cloud_function_test/test_classes/http_test.py
@@ -62,8 +62,8 @@ class HttpFunctionTest(BaseFunctionTest):
         # assess general status (passed or failed) regardless of the type of success/failure
         if (
             ((response_output == Exception) != (self.error or False))
-            or (self.status_code and self.status_code != response_status)
-            or (self.output and not partial_matching(self.output, response_output))
+            or (self.status_code is not None and self.status_code != response_status)
+            or (self.output is not None and not partial_matching(self.output, response_output))
         ):
             status = "failed"
             print(f"test {self.name} in {response_time}s: ", colored("FAILED", 'red'))
@@ -80,11 +80,11 @@ class HttpFunctionTest(BaseFunctionTest):
             display_message.append(f"Function did not crash while an error was expected")
             display_message.append(f"- received: {response_status}, {response_output}")
         else:
-            if self.status_code and self.status_code != response_status:
+            if self.status_code is not None and self.status_code != response_status:
                 display_message.append(f"Unexpected status code")
                 display_message.append(f"- expected: {self.status_code}")
                 display_message.append(f"- received: {response_status}")
-            if self.output and self.output != response_output:
+            if self.output is not None and self.output != response_output:
                 display_message.append(f"Unexpected output")
                 display_message.append(f"- expected: {self.output}")
                 display_message.append(f"- received: {response_output}")

--- a/cloud_function_test/test_classes/http_test.py
+++ b/cloud_function_test/test_classes/http_test.py
@@ -40,9 +40,9 @@ class HttpFunctionTest(BaseFunctionTest):
         Save the response in self.response
         """
         params = {'url': url}
-        if self.headers:
+        if self.headers is not None:
             params['headers'] = self.headers
-        if self.data:
+        if self.data is not None:
             params['json'] = self.data
         self.response = requests.post(**params)
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,9 +1,10 @@
 import re
 from typing import Any
+from typing import Dict
+from typing import List
 from typing import Tuple
 from typing import Type
 from typing import Union
-from typing import List
 from typing import _SpecialForm
 
 import pytest


### PR DESCRIPTION
This PR aims at fixing the linked issue. The problem lied in the use of `not <var>` to test whether the var is None but that was also unintentionally including empty lists and dicts. The fix is simply to use `<var> is not None`.
I've also added some small changes to the README