### PR TITLE
Fix bug with tuples in the matching function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can specify 4 additional attributes for those:
 
 It's quite common to want to check the validity of the output of an http-triggered Cloud Function without knowing the exact value of the expected output. This happens for instance if you Cloud Function is calling an external service or if your output includes an "updated_at" timestamp. In that case, you may want to test that the structure of the output is correct rather than the exact content.
 
-There are 2 types of wildcards your can use for that purpose:
+There are 3 types of wildcards your can use for that purpose:
 * Ellipsis
     * If you include this object in a list, the test will only check that the other elements of the list are found in the actual output
     ```
@@ -127,13 +127,13 @@ There are 2 types of wildcards your can use for that purpose:
     * If you pass this object as a key in a dict, the test will only check that all other key/value pairs are found in the actual output
     ```
     A:
-        output = {"a": 1, "b": Ellipsis}
+        output = {"a": 1, Ellipsis: Ellipsis}
     ```
     This will match with `actual_output = {"a": 1, "b": 2, "c": 3}`
 * Types
 
-    You can include both basic types (int, str...) and types from the typing package (Union, Tuple...) in the expected output.
-    * Rather simple case
+    You can include both basic/collection types (int, float, str, list, dict) and types from the typing package (Any, Union, List, Tuple, Dict) in the expected output.
+    * Simple case
         ```
         A:
             output = List[int]
@@ -142,11 +142,18 @@ There are 2 types of wildcards your can use for that purpose:
     * More complex example
         ```
         A:
-            output = Tuple[dict, List[int]]
+            output = Tuple[dict, List[int], Union[int, str]]
         ```
-        This will match with `actual_output = ({"a": 1}, [1, 2])`
-    
-    We cannot ensure you that the most complex cases are covered unfortunately
+        This will match with `actual_output = [{"a": 1}, [1, 2], "b"]`
+* Regex
+
+    You can include an object of type re.Pattern in your expected output. If the actual output is a string, it will be matched with the pattern.
+    ```
+    A:
+        output = ["a", re.compile(r'^\d+$')]
+    ```
+    This will match with `actual_output = ["a", "123a"]`
+
 
 ### Event-triggered Functions <a name="event-triggered-functions"></a>
 

--- a/cloud_functions_test/matching.py
+++ b/cloud_functions_test/matching.py
@@ -16,27 +16,61 @@ def partial_matching(expected: Any, actual: Any) -> bool:
     Supports the use of types (either native or typing) in the expected object
     """
 
-    # in case of a type
-    if (
-        isinstance(expected, type)
-        or hasattr(expected, '__origin__')
-        or (
-            hasattr(expected, '__module__')
-            and expected.__module__ == 'typing'
-        )
-    ):
-        return is_instance_of_type(actual, expected)
+    # modify instance tuples as expected into lists because tuple is not json serializable
+    if isinstance(expected, tuple):
+        expected = list(expected)
 
-    # in case of a regex
+    # basic types
+    try:
+        if isinstance(actual, expected):
+            return True
+    except TypeError:
+        pass
+
+    # typing.Any
+    if isinstance(expected, _SpecialForm) and expected._name == "Any":
+        return True
+
+    # typing.Union
+    if hasattr(expected, '__origin__') and expected.__origin__ is Union:
+        return any(partial_matching(t, actual) for t in expected.__args__)
+
+    # typing.List
+    if hasattr(expected, '__origin__') and expected.__origin__ is list:
+        if not isinstance(actual, list):
+            return False
+        element_type = expected.__args__[0]
+        return all(partial_matching(element_type, a) for a in actual)
+
+    # typing.Tuple
+    if hasattr(expected, '__origin__') and expected.__origin__ is tuple:
+        # tuple is not json-serializable so it's transformed into a list
+        if not isinstance(actual, list):
+            return False
+        element_types = expected.__args__
+        if len(element_types) != len(actual):
+            return False
+        return all(
+            partial_matching(element_type, a)
+            for a, element_type in zip(actual, element_types)
+        )
+
+    # typing.Dict
+    if hasattr(expected, '__origin__') and expected.__origin__ is dict:
+        if not isinstance(actual, dict):
+            return False
+        key_type, value_type = expected.__args__
+        return all(
+            partial_matching(key_type, k) and partial_matching(value_type, v)
+            for k, v in actual.items()
+        )
+
+    # instance regex
     if isinstance(expected, re.Pattern) and isinstance(actual, str):
         return bool(expected.match(actual))
 
-    # after having checked the 2 above, if the objects have different types they are necessarily not matching
-    elif type(expected) != type(actual):
-        return False
-
-    # in case of a list or tuple
-    elif isinstance(expected, (list, tuple)):
+    # instance list
+    elif isinstance(expected, list):
         if Ellipsis in expected:
             expected = [item for item in expected if item != Ellipsis]
             actual = actual[:len(expected)]
@@ -44,84 +78,12 @@ def partial_matching(expected: Any, actual: Any) -> bool:
             return False
         return all(partial_matching(e, a) for e, a in zip(expected, actual))
 
-    # in case of a dict
+    # instance dict
     elif isinstance(expected, dict):
         if not Ellipsis in expected and not expected.keys() == actual.keys():
             return False
         else:
             return all(partial_matching(expected[key], actual[key]) for key in expected if not expected[key] == Ellipsis)
 
-    # in case of a set
-    elif isinstance(expected, set):
-        if Ellipsis in expected:
-            expected = {item for item in expected if item != Ellipsis}
-        elif len(expected) != len(actual):
-            return False
-        return all(
-            any(partial_matching(e, a) for a in actual)
-            for e in expected
-        )
-
     # for all other types
     return expected == actual
-
-
-def is_instance_of_type(value: Any, type_hint: Any) -> bool:
-    """
-    Return whether the value is an instance of the type_hint
-    Supports both basic types and types from the typing package
-    The function is recursive to support more complex typing types (Union, List...)
-    May not work for the most complex cases
-    """
-
-    # in case type_hint is a basic type
-    try:
-        if isinstance(value, type_hint):
-            return True
-    except TypeError:
-        pass
-
-    # in case type_hint = Any
-    if isinstance(type_hint, _SpecialForm):
-        if type_hint._name == "Any":
-            return True
-
-    # in case type_hint = Union
-    if hasattr(type_hint, '__origin__') and type_hint.__origin__ is Union:
-        return any(is_instance_of_type(value, t) for t in type_hint.__args__)
-
-    # in case type_hint = List
-    if hasattr(type_hint, '__origin__') and type_hint.__origin__ is list:
-        if not isinstance(value, list):
-            return False
-        element_type = type_hint.__args__[0]
-        return all(is_instance_of_type(element, element_type) for element in value)
-
-    # in case type_hint = Dict
-    if hasattr(type_hint, '__origin__') and type_hint.__origin__ is dict:
-        if not isinstance(value, dict):
-            return False
-        key_type, value_type = type_hint.__args__
-        return all(
-            is_instance_of_type(k, key_type) and is_instance_of_type(v, value_type)
-            for k, v in value.items()
-        )
-
-    # in case type_hint = Tuple
-    if hasattr(type_hint, '__origin__') and type_hint.__origin__ is tuple:
-        if not isinstance(value, tuple):
-            return False
-        element_types = type_hint.__args__
-        if len(element_types) != len(value):
-            return False
-        return all(
-            is_instance_of_type(element, element_type)
-            for element, element_type in zip(value, element_types)
-        )
-
-    # in case type_hint = Set
-    if hasattr(type_hint, '__origin__') and type_hint.__origin__ is set:
-        return True
-
-    # cases not covered
-    return False

--- a/cloud_functions_test/test_classes/http_test.py
+++ b/cloud_functions_test/test_classes/http_test.py
@@ -84,7 +84,7 @@ class HttpFunctionTest(BaseFunctionTest):
                 display_message.append(f"Unexpected status code")
                 display_message.append(f"- expected: {self.status_code}")
                 display_message.append(f"- received: {response_status}")
-            if self.output is not None and self.output != response_output:
+            if self.output is not None and not partial_matching(self.output, response_output):
                 display_message.append(f"Unexpected output")
                 display_message.append(f"- expected: {self.output}")
                 display_message.append(f"- received: {response_output}")

--- a/examples/basic_http_triggered/cf_tests.py
+++ b/examples/basic_http_triggered/cf_tests.py
@@ -1,25 +1,35 @@
+from typing import Any, Dict, List
+
+
 class CorrectInput:
     data = {"a": 1}
     headers = {'Content-Type': 'application/json'}
     status_code = 200
     output = {"a": 1, "b": 2}
 
-
 class IncorrectInput:
     data = {1: 2}
     headers = {'Content-Type': 'application/json'}
     status_code = 400
-    display_logs = True
 
+class IncorrectInputTypingEllipsis:
+    data = {"a": [{"a": 1}], "b": 1, "c": 1, "d": 1}
+    headers = {'Content-Type': 'application/json'}
+    status_code = 200
+    output = {"a": List[Dict[str, int]], "b": Any, Ellipsis:Ellipsis}
 
 class CrashInput:
     data = ["a"]
     headers = {'Content-Type': 'application/json'}
     error = True 
 
-
 class OopsUnintendedError:
     data = {"a": "1"}
     headers = {'Content-Type': 'application/json'}
     status_code = 200
     output = {"a": 1, "b": 2}
+
+
+
+
+

--- a/examples/basic_http_triggered/cf_tests.py
+++ b/examples/basic_http_triggered/cf_tests.py
@@ -28,8 +28,3 @@ class OopsUnintendedError:
     headers = {'Content-Type': 'application/json'}
     status_code = 200
     output = {"a": 1, "b": 2}
-
-
-
-
-

--- a/examples/basic_http_triggered/main.py
+++ b/examples/basic_http_triggered/main.py
@@ -6,4 +6,4 @@ def main(request):
     logging.info(value)
     if "a" not in value:
         return ("Error", 400)
-    return ({**value, "b": 2}, 200)
+    return ([{1, 2}], 200)

--- a/examples/basic_http_triggered/main.py
+++ b/examples/basic_http_triggered/main.py
@@ -6,4 +6,4 @@ def main(request):
     logging.info(value)
     if "a" not in value:
         return ("Error", 400)
-    return ([{1, 2}], 200)
+    return ({**value, "b": 2}, 200)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 
 name = "cloud-functions-test"
-version = "0.0.1"
+version = "0.0.2"
 
 
 with open('README.md', 'r') as f:


### PR DESCRIPTION
There was an issue with the typing.Tuple type in the expected output of http functions. This PR refactors the partial_matching function to fix it. There was also a small inattention mistake in the check_validity_result of the http test class. Finally, it updates the README